### PR TITLE
remove wrong answer

### DIFF
--- a/QA.js
+++ b/QA.js
@@ -53,7 +53,6 @@ QA = {
     '下面哪个州，没有state income tax?': [
         'Alaska',
         'Florida',
-        'New Hampshire',
     ],
     '下面哪个州，有state income tax': [
         'Mississippi',


### PR DESCRIPTION
> New Hampshire has no income tax on wages and salaries. However, there is a 5% tax on interest and dividends.

[source](https://smartasset.com/taxes/new-hampshire-tax-calculator)